### PR TITLE
Add GitHub homepage preview to Gutenberg page

### DIFF
--- a/gutenberg.html
+++ b/gutenberg.html
@@ -58,6 +58,25 @@ pre > code.sourceCode > span > a:first-child::before { text-decoration: underlin
 }
 </style>
 
+<style>
+  .github-preview {
+    margin: 2rem 0;
+  }
+
+  .github-preview iframe {
+    width: 100%;
+    min-height: 700px;
+    border: 1px solid #d0d7de;
+    border-radius: 0.5rem;
+  }
+
+  .github-preview__notice {
+    font-size: 0.95rem;
+    margin-top: 0.5rem;
+    color: #495057;
+  }
+</style>
+
 
 <script src="gutenberg_files/libs/clipboard/clipboard.min.js"></script>
 <script src="gutenberg_files/libs/quarto-html/quarto.js" type="module"></script>
@@ -79,6 +98,15 @@ pre > code.sourceCode > span > a:first-child::before { text-decoration: underlin
 <div id="quarto-content" class="page-columns page-rows-contents page-layout-article">
 
 <main class="content" id="quarto-document-content">
+
+<section id="github-home" class="level2">
+<h2 class="anchored" data-anchor-id="github-home">GitHub Homepage Preview</h2>
+<p>아래에는 <a href="https://github.com/yuu9451-cpu" target="_blank" rel="noopener">https://github.com/yuu9451-cpu</a> 저장소의 최신 홈페이지 화면을 보여주는 미리보기 창이 포함되어 있습니다. 새로운 내용이 추가되면 GitHub 페이지가 자동으로 반영됩니다.</p>
+<div class="github-preview">
+  <iframe src="https://r.jina.ai/https://github.com/yuu9451-cpu" title="yuu9451-cpu GitHub homepage"></iframe>
+  <p class="github-preview__notice">만약 미리보기가 보이지 않는다면 위 링크를 눌러 새 창에서 직접 확인할 수 있습니다.</p>
+</div>
+</section>
 
 <header id="title-block-header" class="quarto-title-block default">
 <div class="quarto-title">


### PR DESCRIPTION
## Summary
- add a GitHub homepage preview section at the top of `gutenberg.html`
- embed the public page through a responsive iframe along with a fallback link
- include lightweight styling for the preview container

## Testing
- not run; static HTML update


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6917a342180c8331b3a7d0d3b178d1fa)